### PR TITLE
Fix tile overlap issue in week/day/hour views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/LevioMeel/react-scheduler-Konard/issues/1
+Your prepared branch: issue-1-b4d075d1
+Your prepared working directory: /tmp/gh-issue-solver-1758515428378
+Your forked repository: konard/react-scheduler-Konard
+Original repository (upstream): LevioMeel/react-scheduler-Konard
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/LevioMeel/react-scheduler-Konard/issues/1
-Your prepared branch: issue-1-b4d075d1
-Your prepared working directory: /tmp/gh-issue-solver-1758515428378
-Your forked repository: konard/react-scheduler-Konard
-Original repository (upstream): LevioMeel/react-scheduler-Konard
-
-Proceed.

--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -46,7 +46,7 @@ export const Calendar: FC<CalendarProps> = ({
     next,
     previous,
     reset
-  } = usePagination(filteredData);
+  } = usePagination(filteredData, zoom);
   const debouncedHandleMouseOver = useRef(
     debounce(
       (

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { SchedulerData } from "@/types/global";
+import { SchedulerData, ZoomLevel } from "@/types/global";
 import { splitToPages } from "@/utils/splitToPages";
 import { projectsOnGrid } from "@/utils/getProjectsOnGrid";
 import { getTotalRowsPerPage } from "@/utils/getTotalRowsPerPage";
@@ -7,7 +7,7 @@ import { useCalendar } from "@/context/CalendarProvider";
 import { outsideWrapperId } from "@/constants";
 import { UsePaginationData } from "./types";
 
-export const usePagination = (data: SchedulerData): UsePaginationData => {
+export const usePagination = (data: SchedulerData, zoom: ZoomLevel): UsePaginationData => {
   const { recordsThreshold } = useCalendar();
   const [startIndex, setStartIndex] = useState(0);
   const [pageNum, setPage] = useState(0);
@@ -17,7 +17,10 @@ export const usePagination = (data: SchedulerData): UsePaginationData => {
     outsideWrapper.current = document.getElementById(outsideWrapperId);
   }, []);
 
-  const { projectsPerPerson, rowsPerPerson } = useMemo(() => projectsOnGrid(data), [data]);
+  const { projectsPerPerson, rowsPerPerson } = useMemo(
+    () => projectsOnGrid(data, zoom),
+    [data, zoom]
+  );
 
   const pages = useMemo(
     () => splitToPages(data, projectsPerPerson, rowsPerPerson, recordsThreshold),

--- a/src/utils/getProjectsOnGrid.ts
+++ b/src/utils/getProjectsOnGrid.ts
@@ -1,12 +1,12 @@
-import { SchedulerData, SchedulerProjectData } from "@/types/global";
+import { SchedulerData, SchedulerProjectData, ZoomLevel } from "@/types/global";
 import { setProjectsInRows } from "./setProjectsInRows";
 
 type ProjectsData = [projectsPerPerson: SchedulerProjectData[][][], rowsPerPerson: number[]];
 
-export const projectsOnGrid = (data: SchedulerData) => {
+export const projectsOnGrid = (data: SchedulerData, zoom: ZoomLevel = 0) => {
   const initialProjectsData: ProjectsData = [[], []];
   const [projectsPerPerson, rowsPerPerson] = data.reduce((acc, curr) => {
-    const projectsInRows = setProjectsInRows(curr.data);
+    const projectsInRows = setProjectsInRows(curr.data, zoom);
     acc[0].push(projectsInRows);
     acc[1].push(Math.max(projectsInRows.length, 1));
     return acc;

--- a/src/utils/setProjectsInRows.ts
+++ b/src/utils/setProjectsInRows.ts
@@ -1,24 +1,37 @@
 import dayjs from "dayjs";
-import { SchedulerProjectData } from "@/types/global";
+import { SchedulerProjectData, ZoomLevel } from "@/types/global";
 
-export const setProjectsInRows = (projects: SchedulerProjectData[]): SchedulerProjectData[][] => {
+export const setProjectsInRows = (
+  projects: SchedulerProjectData[],
+  zoom: ZoomLevel = 0
+): SchedulerProjectData[][] => {
   const rows: SchedulerProjectData[][] = [];
+
+  // Determine the time unit for collision detection based on zoom level
+  // zoom 0 = week view - use day precision
+  // zoom 1 = day view - use hour precision
+  // zoom 2 = hour view - use minute precision
+  const timeUnit = zoom === 2 ? "minute" : zoom === 1 ? "hour" : "day";
+
   for (const project of projects) {
     let isAdded = false;
     if (rows.length) {
       for (const row of rows) {
         let isColliding = false;
         for (let i = 0; i < row.length; i++) {
+          // Check if project overlaps with existing tile in the row
+          // Using the appropriate time unit based on zoom level
           if (
-            dayjs(project.startDate).isBetween(row[i].startDate, row[i].endDate, null, "[]") ||
-            dayjs(project.endDate).isBetween(row[i].startDate, row[i].endDate, null, "[]")
+            dayjs(project.startDate).isBetween(row[i].startDate, row[i].endDate, timeUnit, "[]") ||
+            dayjs(project.endDate).isBetween(row[i].startDate, row[i].endDate, timeUnit, "[]")
           ) {
             isColliding = true;
             break;
           }
+          // Check if project completely encompasses an existing tile
           if (
-            dayjs(project.startDate).isBefore(row[i].startDate, "day") &&
-            dayjs(project.endDate).isAfter(row[i].endDate, "day")
+            dayjs(project.startDate).isBefore(row[i].startDate, timeUnit) &&
+            dayjs(project.endDate).isAfter(row[i].endDate, timeUnit)
           ) {
             isColliding = true;
             break;


### PR DESCRIPTION
## Summary

This PR fixes the tile overlap issue where short-term tiles were incorrectly overlapping in week/day/hour views due to collision detection not considering the appropriate time granularity for each zoom level.

## Problem

The collision detection logic in `setProjectsInRows` was always using day-level precision regardless of the current zoom level. This caused tiles that don't actually overlap at finer time scales to be incorrectly placed on separate rows.

## Solution

Updated the collision detection to use appropriate time units based on zoom level:
- **Week view (zoom 0)**: Uses day-level precision for collision detection
- **Day view (zoom 1)**: Uses hour-level precision for collision detection  
- **Hour view (zoom 2)**: Uses minute-level precision for collision detection

## Changes

1. **`setProjectsInRows.ts`**: Enhanced to accept zoom parameter and use appropriate time unit for collision detection
2. **`getProjectsOnGrid.ts`**: Updated to pass zoom parameter to setProjectsInRows
3. **`usePagination.ts`**: Modified to accept and pass zoom parameter through
4. **`Calendar.tsx`**: Updated to pass zoom to usePagination hook

## Testing

The fix has been:
- ✅ Built successfully with TypeScript
- ✅ Passed ESLint checks for all modified files
- ✅ Tested with sample data to verify correct tile placement at different zoom levels

## Test Plan

1. Create tiles with overlapping times at different granularities
2. Switch between week/day/hour views
3. Verify tiles only appear on separate rows when they actually overlap at the current view's time scale

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)